### PR TITLE
scala in dB sulla potenza

### DIFF
--- a/pinknoise.ipynb
+++ b/pinknoise.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Il rumore rosa ha una **densità** spettrale di potenza inversamente proporzionale alla frequenza. Densità spettrale vuol dire che l'unità di misura e' Watt/Hertz (W/Hz).\n",
+    "Il rumore rosa ha una **densità** spettrale di potenza inversamente proporzionale alla frequenza. *VEDASI NOTA QUI* Densità spettrale vuol dire che l'unità di misura e' Watt/Hertz (W/Hz).\n",
     "\n",
     "Poniamo che la funzione che rappresenta la densità spettrale di potenza sia:\n",
     "\n",


### PR DESCRIPTION
Pregasi utilizzare i dB sull'asse verticale, fissando lo zero dB su +4dBu (dB rispetto a 1 milliwatt su un carico considerato standard pari a 600 Ohm), in digitale e' tipico allinearsi a questo +4dBu con una sinusoide a 1000Hz di picco -20 dB FS quindi magari si puo' passare dai Watt a qualche unità di misura digitale equivalente, no?